### PR TITLE
untie PD handle on DESTORYing

### DIFF
--- a/lib/CPAN/Common/Index/Mirror.pm
+++ b/lib/CPAN/Common/Index/Mirror.pm
@@ -256,6 +256,8 @@ sub _match_mailrc_line {
     };
 }
 
+sub DESTROY { untie *PD }
+
 1;
 
 =for Pod::Coverage attributes validate_attributes search_packages search_authors


### PR DESCRIPTION
... so that File::Temp can remove the temporary 02packages safely under Win32

cf. http://www.cpantesters.org/distro/C/CPAN-Common-Index.html#CPAN-Common-Index-0.003?grade=1&perlmat=2&patches=2&oncpan=2&distmat=2&perlver=ALL&osname=mswin32&version=0.003
