### PR TITLE
drop unused prereq Test::Deep

### DIFF
--- a/t/local_package.t
+++ b/t/local_package.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Test::More 0.96;
 use Test::FailWarnings;
-use Test::Deep '!blessed';
 use Test::Fatal;
 
 use Cwd qw/getcwd/;

--- a/t/metadb.t
+++ b/t/metadb.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Test::More 0.96;
 use Test::FailWarnings;
-use Test::Deep '!blessed';
 use Test::Fatal;
 
 use Cwd qw/getcwd/;

--- a/t/mirror.t
+++ b/t/mirror.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Test::More 0.96;
 use Test::FailWarnings;
-use Test::Deep '!blessed';
 use Test::Fatal;
 
 use Cwd qw/getcwd/;

--- a/t/mux-ordered.t
+++ b/t/mux-ordered.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Test::More 0.96;
 use Test::FailWarnings;
-use Test::Deep '!blessed';
 use Test::Fatal;
 use Cwd qw/getcwd/;
 use File::Temp;


### PR DESCRIPTION
Test::Deep was imported in several tests, but none of its functions were actually being used.